### PR TITLE
Ctrl+C on *nix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,11 +20,27 @@ BOOL WINAPI ctrl_c_handler(DWORD signal) {
 }
 #endif
 
+#ifdef unix
+#include <unistd.h>
+void ctrl_c_handler(int signal){
+  app->close();
+  return true;
+}
+#endif
+
 int main(int argc, char** argv) {
 #ifdef _WIN32
   if (!SetConsoleCtrlHandler(ctrl_c_handler, TRUE)) {
     return -1;
   }
+#endif
+#ifdef unix
+  struct sigaction handler;
+   handler.sa_handler = ctrl_c_handler;
+   sigemptyset(&handler.sa_mask);
+   handler.sa_flags = 0;
+
+   sigaction(SIGINT, &handler, NULL);
 #endif
 
   std::vector<std::string> args;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,13 +18,11 @@ BOOL WINAPI ctrl_c_handler(DWORD signal) {
   }
   return TRUE;
 }
-#endif
-
-#ifdef unix
+#elif __linux__
+#include <csignal>
 #include <unistd.h>
 void ctrl_c_handler(int signal){
   app->close();
-  return true;
 }
 #endif
 
@@ -33,13 +31,11 @@ int main(int argc, char** argv) {
   if (!SetConsoleCtrlHandler(ctrl_c_handler, TRUE)) {
     return -1;
   }
-#endif
-#ifdef unix
-  struct sigaction handler;
+#elif __linux__
+   struct sigaction handler;
    handler.sa_handler = ctrl_c_handler;
    sigemptyset(&handler.sa_mask);
    handler.sa_flags = 0;
-
    sigaction(SIGINT, &handler, NULL);
 #endif
 


### PR DESCRIPTION
Closes #1 (i think so). The problem was with `unix` preprocessor macro, which is sometimes missing. I used `__linux__` instead.